### PR TITLE
Add try/except block for cadc-tap keyboard interrupt [#110]

### DIFF
--- a/cadccutout/cadccutout/tests/test_cutoutnd.py
+++ b/cadccutout/cadccutout/tests/test_cutoutnd.py
@@ -138,7 +138,7 @@ def test_extract_striding():
     test_subject = CutoutND(data)
     cutout_regions = [(4, 18, 5)]
     cutout = test_subject.extract(cutout_regions)
-    expected_data = np.array([[3,  8],
+    expected_data = np.array([[3, 8],
                               [13, 18],
                               [23, 28],
                               [33, 38],
@@ -158,7 +158,7 @@ def test_extract_striding_wildcard():
     test_subject = CutoutND(data)
     cutout_regions = [('*', 7)]
     cutout = test_subject.extract(cutout_regions)
-    expected_data = np.array([[0,  7],
+    expected_data = np.array([[0, 7],
                               [10, 17],
                               [20, 27],
                               [30, 37],
@@ -178,7 +178,9 @@ def test_extract_invalid():
     test_subject = CutoutND(data)
     cutout_regions = [('')]
 
-    with pytest.raises(ValueError, match=r".*Should have at least two values \(lower, upper\)\..*"):
+    with pytest.raises(ValueError,
+                       match=r"Should have at least two values "
+                             r"\(lower, upper\)\."):
         test_subject.extract(cutout_regions)
 
 

--- a/cadccutout/cadccutout/tests/test_cutoutnd.py
+++ b/cadccutout/cadccutout/tests/test_cutoutnd.py
@@ -178,11 +178,8 @@ def test_extract_invalid():
     test_subject = CutoutND(data)
     cutout_regions = [('')]
 
-    with pytest.raises(ValueError) as ve:
+    with pytest.raises(ValueError, match=r".*Should have at least two values \(lower, upper\)\..*"):
         test_subject.extract(cutout_regions)
-
-    assert str(ve).index(
-        'Should have at least two values (lower, upper).') > 0
 
 
 def test_with_wcs():

--- a/cadccutout/cadccutout/tests/test_pixel_cutout_hdu.py
+++ b/cadccutout/cadccutout/tests/test_pixel_cutout_hdu.py
@@ -89,11 +89,8 @@ def test_create():
     test_subject = PixelCutoutHDU([(12, 30)], 'EXT,0')
     assert test_subject.get_extension() == ('EXT', 1)
 
-    with pytest.raises(ValueError) as ve:
-        test_subject = PixelCutoutHDU([(23, 67), (23, 89)],
-                                      extension='SCI, 3, i')
-    assert str(ve).index(
-        'Specifying XTENSION return type is not supported.') > 0
+    with pytest.raises(ValueError, match=r".*Specifying XTENSION return type is not supported\..*"):
+        PixelCutoutHDU([(23, 67), (23, 89)], extension='SCI, 3, i')
 
     test_subject = PixelCutoutHDU(extension='5')
     assert test_subject.get_extension() == 5, 'Wrong extension.'

--- a/cadccutout/cadccutout/tests/test_pixel_cutout_hdu.py
+++ b/cadccutout/cadccutout/tests/test_pixel_cutout_hdu.py
@@ -89,7 +89,8 @@ def test_create():
     test_subject = PixelCutoutHDU([(12, 30)], 'EXT,0')
     assert test_subject.get_extension() == ('EXT', 1)
 
-    with pytest.raises(ValueError, match=r".*Specifying XTENSION return type is not supported\..*"):
+    with pytest.raises(ValueError, match=r"Specifying XTENSION return type "
+                                         r"is not supported\."):
         PixelCutoutHDU([(23, 67), (23, 89)], extension='SCI, 3, i')
 
     test_subject = PixelCutoutHDU(extension='5')

--- a/cadcetrans/cadcetrans/tests/test_etrans_core.py
+++ b/cadcetrans/cadcetrans/tests/test_etrans_core.py
@@ -128,7 +128,7 @@ def test_transfer_dryrun(get_files_mock, data_client_mock, config_mock):
     with pytest.raises(CommandError) as e:
         transfer(PROC_DIR, 'new', True, Subject())
     assert 'Errors occurred during transfer ({} error(s))'\
-           .format(len(invalid_files)) in str(e)
+           .format(len(invalid_files)) in str(e.value)
 
     # remove the "invalid" files
     for f in invalid_files:
@@ -180,7 +180,7 @@ def test_transfer(get_files_mock, put_mock, data_client_mock, config_mock):
                  namecheck_file=os.path.join(TESTDATA_DIR,
                                              'namecheck.xml'))
     assert 'Errors occurred during transfer ({} error(s))'\
-           .format(len(invalid_files)) in str(e)
+           .format(len(invalid_files)) in str(e.value)
     assert put_mock.call_count == len(src_files) - len(invalid_files), 'Calls'
     calls = []
     for f in valid_files:
@@ -209,7 +209,7 @@ def test_transfer(get_files_mock, put_mock, data_client_mock, config_mock):
     put_mock.reset_mock()
     transfer(PROC_DIR, 'new', False, subject)
     assert 'Errors occurred during transfer ({} error(s))'\
-           .format(len(invalid_files)) in str(e)
+           .format(len(invalid_files)) in str(e.value)
     assert put_mock.call_count == 0
 
 

--- a/cadctap/cadctap/core.py
+++ b/cadctap/cadctap/core.py
@@ -832,3 +832,6 @@ def main_app(command='cadc-tap query'):
             client.schema(args.tablename)
     except Exception as ex:
         exit_on_exception(ex)
+    except KeyboardInterrupt:
+        sys.stderr.write('KeyboardInterrupt\n')
+        sys.exit(0)

--- a/cadctap/cadctap/tests/test_core.py
+++ b/cadctap/cadctap/tests/test_core.py
@@ -704,3 +704,14 @@ class TestCadcTapClient(unittest.TestCase):
         calls = [call('SELECT TOP 10 target_name FROM caom2.Observation', None,
                       'tsv', None, data_only=False, timeout=2)]
         query_mock.assert_has_calls(calls)
+
+    @patch('cadctap.CadcTapClient.query')
+    def test_keyboard_interrupt(self, query_mock):
+        query_mock.reset_mock()
+        query_mock.side_effect = KeyboardInterrupt()
+        sys.argv = ['cadc-tap', 'query', '-s', 'http://someservice', 'QUERY']
+        with patch('sys.stderr', new_callable=StringIO) as stderr_mock:
+            try:
+                main_app()
+            except SystemExit:
+                assert stderr_mock.getvalue() == 'KeyboardInterrupt\n'


### PR DESCRIPTION
If a user press Ctrl-C during a cadc-tap command line query, now the program will print 'KeyboardInterrupt' and exit, rather than a stack trace [#110 ].

Note that this will only work when using the command line functionality of cadctap, not in a python script. Please let me know if I should add more to this PR!