### PR TITLE
Story 2712. Removed 'Accept-Encoding' from default session.headers. T…

### DIFF
--- a/cadcutils/cadcutils/net/ws.py
+++ b/cadcutils/cadcutils/net/ws.py
@@ -397,6 +397,7 @@ class BaseWsClient(object):
         user_agent = "{} {} {} {} ({})".format(self.agent, self.package_info,
                                                self.python_info,
                                                self.system_info, self.os_info)
+        self._session.headers.pop("Accept-Encoding", None)
         self._session.headers.update({"User-Agent": user_agent})
         if self.session_headers is not None:
             for header in self.session_headers:

--- a/cadcutils/setup.cfg
+++ b/cadcutils/setup.cfg
@@ -42,7 +42,7 @@ install_requires =
     lxml>=3.7.0;python_version>="3.5"
     lxml;python_version=="2.7"
     six html2text distro pyopenssl
-version = 1.1.25
+version = 1.1.26
 
 [entry_points]
 cadc-get-cert = cadcutils.net.auth:get_cert_main


### PR DESCRIPTION
…he 'gzip' encoding was causing job phase not to be received by clients and was showing up in move errors.