### PR TITLE
Cadc 9694 - Make vos (and other clients) more robust to network errors

### DIFF
--- a/cadccutout/cadccutout/tests/__init__.py
+++ b/cadccutout/cadccutout/tests/__init__.py
@@ -1,0 +1,1 @@
+# This exists solely to make coverage collect usage data

--- a/cadccutout/cadccutout/tests/test_mef_cutout.py
+++ b/cadccutout/cadccutout/tests/test_mef_cutout.py
@@ -74,7 +74,7 @@ import logging
 import numpy as np
 import os
 import pytest
-import context as test_context
+from . import context as test_context
 
 from astropy.io import fits
 from astropy.wcs import WCS

--- a/cadccutout/cadccutout/tests/test_scaling.py
+++ b/cadccutout/cadccutout/tests/test_scaling.py
@@ -73,7 +73,7 @@ from __future__ import (absolute_import, division, print_function,
 import logging
 import numpy as np
 import os
-import context as test_context
+from . import context as test_context
 from astropy.io import fits
 
 from cadccutout.core import OpenCADCCutout

--- a/cadccutout/cadccutout/tests/test_simple_cutout.py
+++ b/cadccutout/cadccutout/tests/test_simple_cutout.py
@@ -75,7 +75,7 @@ import numpy as np
 import os
 import sys
 import pytest
-import context as test_context
+from . import context as test_context
 
 from astropy.io import fits
 from astropy.wcs import WCS

--- a/cadccutout/tox.ini
+++ b/cadccutout/tox.ini
@@ -30,7 +30,6 @@ deps:
     -rdev_requirements.txt
 commands =
     pytest {[package]name} --cov {[package]name} --cov-report xml --cov-config={toxinidir}/setup.cfg
-    coverage xml -o {toxinidir}/coverage.xml
 
 
 [testenv:checkstyle]

--- a/cadcdata/cadcdata/core.py
+++ b/cadcdata/cadcdata/core.py
@@ -272,7 +272,7 @@ class CadcDataClient(object):
                                          process_bytes=process_bytes,
                                          md5_check=md5_check)
                 return
-            except (exceptions.TransferException, DownloadError) as e:
+            except exceptions.TransferException as e:
                 # try a different URL
                 self.logger.info(
                     'WARN: Cannot retrieve data from {}. Exception: {}'.
@@ -365,7 +365,7 @@ class CadcDataClient(object):
         if md5_check and (response.headers.get('content-MD5', 0) != 0):
             md5sum = hash_md5.hexdigest()
             if md5sum and response.headers.get('content-MD5', 0) != md5sum:
-                raise DownloadError(
+                raise exceptions.TransferException(
                     'Downloaded file is corrupted: '
                     'expected md5({}) != actual md5({})'.
                     format(response.headers.get('content-MD5', 0), md5sum))
@@ -546,15 +546,6 @@ class CadcDataClient(object):
             for chunk in iter(lambda: f.read(4096), b""):
                 hash_md5.update(chunk)
         return hash_md5.hexdigest()
-
-
-class DownloadError(Exception):
-    """Download error (file corrupted)
-    Attributes:
-        msg
-    """
-    def __init__(self, msg=None):
-        Exception.__init__(self, msg)
 
 
 def main_app():

--- a/cadcdata/cadcdata/core.py
+++ b/cadcdata/cadcdata/core.py
@@ -75,7 +75,6 @@ import os
 import os.path
 import sys
 import time
-import socket
 from clint.textui import progress
 import hashlib
 

--- a/cadcdata/cadcdata/core.py
+++ b/cadcdata/cadcdata/core.py
@@ -272,14 +272,12 @@ class CadcDataClient(object):
                                          process_bytes=process_bytes,
                                          md5_check=md5_check)
                 return
-            except (exceptions.HttpException, socket.timeout) as e:
+            except (exceptions.TransferException, DownloadError) as e:
                 # try a different URL
                 self.logger.info(
                     'WARN: Cannot retrieve data from {}. Exception: {}'.
                     format(url, e))
-                self.logger.warn('Try the next URL')
-                continue
-            except DownloadError as e:
+                self.logger.warning('Try the next URL')
                 if not hasattr(destination, 'read'):
                     # try to cleanup the corrupted file
                     try:
@@ -287,7 +285,7 @@ class CadcDataClient(object):
                     except Exception:
                         # nothing we can do
                         pass
-                raise exceptions.HttpException(str(e))
+                continue
         raise exceptions.HttpException(
             'Unable to download data from any of the available URLs')
 
@@ -467,11 +465,11 @@ class CadcDataClient(object):
                         archive, src_file, round(duration, 2),
                         round(stat_info.st_size / 1024 / 1024 / duration, 2)))
                 return
-            except (exceptions.HttpException, socket.timeout) as e:
+            except exceptions.TransferException as e:
                 # try a different URL
                 self.logger.info('WARN: Cannot put data to {}. Exception: {}'.
                                  format(url, e))
-                self.logger.warn('Try the next URL')
+                self.logger.warning('Try the next URL')
                 continue
         raise exceptions.HttpException(
             'Unable to put data from any of the available URLs')

--- a/cadcdata/cadcdata/intTests/README
+++ b/cadcdata/cadcdata/intTests/README
@@ -1,0 +1,5 @@
+Invoke integration tests with command:
+    pytest cadcdata -m intTests
+
+Note that some of tests require CADC credentials (valid $HOME/.ssl/cadcproxy.pem certificate)
+and work for CADC staff only.

--- a/cadcdata/cadcdata/intTests/test_int_inventory.py
+++ b/cadcdata/cadcdata/intTests/test_int_inventory.py
@@ -170,8 +170,8 @@ def test_client_authenticated():
         file_info = None
         for resource_id in location_resource_ids:
             try:
-                location_client = StorageInventoryClient(subject=subject,
-                                                         resource_id=resource_id)
+                location_client = StorageInventoryClient(
+                    subject=subject, resource_id=resource_id)
                 file_info = location_client.cadcinfo(global_id)
                 break
             except exceptions.NotFoundException:

--- a/cadcdata/cadcdata/intTests/test_int_inventory.py
+++ b/cadcdata/cadcdata/intTests/test_int_inventory.py
@@ -66,23 +66,34 @@
 
 import pytest
 import os
+from urllib.parse import urlparse
 import hashlib
+import filecmp
+from os.path import expanduser
+import random
+import requests
 
 from cadcdata import StorageInventoryClient
 from cadcutils.net import Subject
 from cadcutils.util import str2ivoa
+from cadcutils import exceptions
+
+REG_HOST = 'https://www.cadc-ccda.hia-iha.nrc-cnrc.gc.ca'
+
+HOME = expanduser("~")
+CERT = os.path.join(HOME, '.ssl/cadcproxy.pem')
 
 
-@pytest.mark.intTest
+@pytest.mark.intTests
 def test_client_public():
-    # file info
+    # file info - NOTE: Test relies on an existing file not to be updated.
     client = StorageInventoryClient(Subject())
     file_info = client.cadcinfo('cadc:IRIS/I429B4H0.fits')
     assert 'cadc:IRIS/I429B4H0.fits' == file_info.id
     assert 1008000 == file_info.size
     assert 'I429B4H0.fits' == file_info.name
     assert 'e3922d47243563529f387ebdf00b66da' == file_info.md5sum
-    timestamp = str2ivoa('2012-06-20T00:31:00.000')
+    timestamp = str2ivoa('2012-06-20T12:31:00.000')
     assert timestamp == file_info.lastmod
     assert 'application/fits' == file_info.file_type
     assert file_info.encoding is None
@@ -108,9 +119,127 @@ def test_client_public():
     # TODO cutouts
 
 
-@pytest.mark.intTest
-@pytest.mark.auth
+@pytest.mark.intTests
+@pytest.mark.skipif(not os.path.isfile(CERT),
+                    reason='CADC credentials required in '
+                           '$HOME/.ssl/cadcproxy.pem')
 def test_client_authenticated():
     """ uses $HOME/.ssl/cadcproxy.pem certificates"""
-    # TODO
-    pass
+    # create a random root for file IDs
+    test_file = '/tmp/cadcdata-inttest.txt'
+    id_root = 'cadc:TEST/cadcdata-intttest-{}'.format(random.randrange(100000))
+    global_id = id_root + '/global'
+    file_name = global_id.split('/')[-1]
+    dest_file = os.path.join('/tmp', file_name)
+    try:
+
+        subject = Subject(certificate=CERT)
+
+        if os.path.isfile(test_file):
+            os.remove(test_file)
+        with open(test_file, 'a') as f:
+            f.write('THIS IS A TEST')
+
+        md5 = hashlib.md5()
+        with open(test_file, 'rb') as f:
+            md5.update(f.read())
+        md5sum = md5.hexdigest()
+        file_size = os.stat(test_file).st_size
+        # find out locations
+        reg = requests.get('{}/reg/resource-caps'.format(REG_HOST)).text
+        location_resource_ids = []
+        for line in reg.split('\n'):
+            line.strip()
+            if not line.startswith('#') and ('minoc' in line) and (
+                    '/ad/minoc' not in line):
+                location_resource_ids.append(line.split('=')[0].strip())
+
+        # test all operations on a location
+        for resource_id in location_resource_ids:
+            location_operations(subject=subject, resource_id=resource_id,
+                                file=test_file, id_root=id_root,
+                                md5sum=md5sum, size=file_size)
+
+        # to test global without waiting for the eventual consistency to occur,
+        # put the file to global and look for it in at least one of the
+        # location. get it and then remove it from that location
+        client = StorageInventoryClient(subject=subject)
+
+        client.cadcput(id=global_id, src=test_file)
+
+        file_info = None
+        for resource_id in location_resource_ids:
+            try:
+                location_client = StorageInventoryClient(subject=subject,
+                                                         resource_id=resource_id)
+                file_info = location_client.cadcinfo(global_id)
+                break
+            except exceptions.NotFoundException:
+                continue
+        assert file_info, 'File not found on any location'
+        assert global_id == file_info.id
+        assert file_size == file_info.size
+        assert md5sum == file_info.md5sum
+
+        if os.path.isfile(dest_file):
+            os.remove(dest_file)
+        location_client.cadcget(global_id, dest=dest_file)
+        assert filecmp.cmp(test_file, dest_file)
+
+        # remove the file
+        location_client.cadcremove(global_id)
+
+        with pytest.raises(exceptions.NotFoundException):
+            location_client.cadcinfo(global_id)
+
+        with pytest.raises(exceptions.NotFoundException):
+            location_client.cadcget(global_id)
+    finally:
+        # cleanup
+        if os.path.isfile(dest_file):
+            os.remove(dest_file)
+        if os.path.isfile(test_file):
+            os.remove(test_file)
+
+
+def location_operations(subject, resource_id, file, id_root, md5sum, size):
+    # tests cadcput, cadcinfo, cadcget and cadcremove on a specific location
+    location = urlparse(resource_id).path.replace('/', '_')
+    si_id = id_root + '/' + location
+    file_name = si_id.split('/')[-1]
+    dest_file = os.path.join('/tmp', file_name)
+    try:
+
+        location_client = StorageInventoryClient(subject=subject,
+                                                 resource_id=resource_id)
+        # put the file
+        location_client.cadcput(id=si_id, src=file)
+
+        # get info about the file
+        file_info = location_client.cadcinfo(id=si_id)
+
+        assert si_id == file_info.id
+        assert file_name == file_info.name
+        assert size == file_info.size
+        assert md5sum == file_info.md5sum
+
+        # get the file
+
+        if os.path.isfile(dest_file):
+            os.remove(dest_file)
+
+        location_client.cadcget(id=si_id, dest='/tmp')
+        assert filecmp.cmp(file, dest_file)
+
+        # remove the file
+        location_client.cadcremove(si_id)
+
+        with pytest.raises(exceptions.NotFoundException):
+            location_client.cadcinfo(si_id)
+
+        with pytest.raises(exceptions.NotFoundException):
+            location_client.cadcget(si_id)
+    finally:
+        # cleanup
+        if os.path.isfile(dest_file):
+            os.remove(dest_file)

--- a/cadcdata/cadcdata/storageinv.py
+++ b/cadcdata/cadcdata/storageinv.py
@@ -244,6 +244,7 @@ class StorageInventoryClient(object):
         self.resource_id = resource_id
         self.host = host
         agent = '{}/{}'.format('SIClient', version.version)
+        # TODO
         # Storage Inventory does not support Basic Auth. The following block
         # retrieves a cookie instead. It is temporary until the token spec
         # is finalized

--- a/cadcdata/cadcdata/storageinv.py
+++ b/cadcdata/cadcdata/storageinv.py
@@ -75,11 +75,19 @@ import socket
 from clint.textui import progress
 import hashlib
 import datetime
+import traceback
+from urllib.parse import urlparse, urlencode
 
 from cadcutils import net, util, exceptions
 from cadcutils.util import date2ivoa
 
 from cadcdata import version
+
+CADC_AC_SERVICE = 'ivo://cadc.nrc.ca/gms'
+CADC_LOGIN_CAPABILITY = 'ivo://ivoa.net/std/UMS#login-0.1'
+CADC_SSO_COOKIE_NAME = 'CADC_SSO'
+CADC_REALMS = ['.canfar.net', '.cadc-ccda.hia-iha.nrc-cnrc.gc.ca',
+               '.cadc.dao.nrc.ca', '.canfar.phys.uvic.ca']
 
 MAGIC_WARN = None
 try:
@@ -146,6 +154,38 @@ class FileInfo:
                                self.md5sum))
 
 
+def handle_error(exception, exit_after=True):
+    """
+    Prints error message and exit (by default)
+    :param msg: error message to print
+    :param exit_after: True if log error message and exit,
+    False if log error message and return
+    :return:
+    """
+
+    if isinstance(exception, exceptions.UnauthorizedException):
+        # TODO - magic authentication
+        # if subject.anon:
+        #     handle_error('Operation cannot be performed anonymously. '
+        #                  'Use one of the available methods to authenticate')
+        # else:
+        print('ERROR: Unexpected authentication problem')
+    elif isinstance(exception, exceptions.NotFoundException):
+        print('ERROR: Not found: {}'.format(str(exception)))
+    elif isinstance(exception, exceptions.ForbiddenException):
+        print('ERROR: Unauthorized to perform operation')
+    elif isinstance(exception, exceptions.UnexpectedException):
+        print('ERROR: Unexpected server error: {}'.format(str(exception)))
+    else:
+        print('ERROR: {}'.format(exception))
+
+    if logger.isEnabledFor(logging.DEBUG):
+        traceback.print_stack()
+
+    if exit_after:
+        sys.exit(-1)  # TODO use different error codes?
+
+
 class StorageInventoryClient(object):
     """Class to access CADC storage inventory.
 
@@ -204,6 +244,34 @@ class StorageInventoryClient(object):
         self.resource_id = resource_id
         self.host = host
         agent = '{}/{}'.format('SIClient', version.version)
+        # Storage Inventory does not support Basic Auth. The following block
+        # retrieves a cookie instead. It is temporary until the token spec
+        # is finalized
+        if resource_id.startswith('ivo://cadc.nrc.ca') and\
+           net.auth.SECURITY_METHODS_IDS['basic'] in \
+           subject.get_security_methods():
+            login = net.BaseWsClient(CADC_AC_SERVICE, net.Subject(),
+                                     agent,
+                                     retry=True, host=self.host)
+            login_url = login._get_url((CADC_LOGIN_CAPABILITY, None))
+            realm = urlparse(login_url).hostname
+            auth = subject.get_auth(realm)
+            if not auth:
+                raise RuntimeError(
+                    'No user/password for realm {} in .netrc'.format(realm))
+            data = urlencode([('username', auth[0]), ('password', auth[1])])
+            headers = {
+                "Content-type": "application/x-www-form-urlencoded",
+                "Accept": "text/plain"
+            }
+            cookie_response = \
+                login.post((CADC_LOGIN_CAPABILITY, None), data=data,
+                           headers=headers)
+            cookie_response.raise_for_status()
+            for cadc_realm in CADC_REALMS:
+                subject.cookies.append(
+                    net.auth.CookieInfo(cadc_realm, CADC_SSO_COOKIE_NAME,
+                                        '"{}"'.format(cookie_response.text)))
         self._cadc_client = net.BaseWsClient(resource_id, subject,
                                              agent, retry=True, host=self.host,
                                              insecure=insecure)
@@ -285,28 +353,28 @@ class StorageInventoryClient(object):
                     # remove any path information and save the file in local
                     # directory
                     dest = os.path.basename(dest)
-                    logger.info('Saved file in local directory under: {}'.
+                    logger.debug('Saved file in local directory under: {}'.
                                 format(dest))
                     with open(dest, 'wb') as f:
                         self._save_bytes(response, f, id,
                                          process_bytes=process_bytes)
                 return
-            except (exceptions.HttpException, socket.timeout) as e:
+            except (exceptions.TransferException) as e:
                 # try a different URL
-                logger.info(
+                logger.debug(
                     'WARN: Cannot retrieve data from {}. Exception: {}'.
                     format(url, e))
-                logger.warn('Try the next URL')
-                continue
-            except DownloadError as e:
+                logger.debug('Try the next URL')
                 if not hasattr(dest, 'read'):
                     # try to cleanup the corrupted file
+                    # TODO should save in a temporary file and do a mv
+                    # at the end
                     try:
                         os.unlink(dest)
                     except Exception:
                         # nothing we can do
                         pass
-                raise exceptions.HttpException(str(e))
+                continue
         raise exceptions.HttpException(
             'Unable to download data to any of the available URLs')
 
@@ -380,12 +448,12 @@ class StorageInventoryClient(object):
         src_md5sum = rr.md5sum
         dest_md5sum = hash_md5.hexdigest()
         if src_md5sum != dest_md5sum:
-            raise DownloadError(
+            raise exceptions.TransferException(
                 'Downloaded file is corrupted: '
                 'expected md5({}) != actual md5({})'.
                 format(src_md5sum, dest_md5sum))
         duration = time.time() - start
-        logger.info(
+        logger.debug(
             'Successfully downloaded file {} as {} in {}s (avg. speed: {}MB/s)'
             ''.format(resource, dest_file.name, round(duration, 2),
                       round(total_length / 1024 / 1024 / duration, 2)))
@@ -466,7 +534,7 @@ class StorageInventoryClient(object):
                (file_info.encoding != headers['Content-Encoding']):
                 operation = 'post'
             else:
-                logger.info(
+                logger.debug(
                     'Source {} already in the storage inventory'.format(src))
                 return
 
@@ -492,17 +560,17 @@ class StorageInventoryClient(object):
                     self._cadc_client.put(url, headers=headers, data=f)
                 duration = time.time() - start
                 stat_info = os.stat(src)
-                logger.info(
+                logger.debug(
                     ('Successfully uploaded file {} in {}s '
                      '(avg. speed: {}MB/s)').format(
                         id, round(duration, 2),
                         round(stat_info.st_size / 1024 / 1024 / duration, 2)))
                 return
-            except (exceptions.HttpException, socket.timeout) as e:
+            except exceptions.TransferException as e:
                 # try a different URL
-                logger.info('WARN: Cannot {} data to {}. Exception: {}'.
+                logger.debug('WARN: Cannot {} data to {}. Exception: {}'.
                             format(operation, url, e))
-                logger.warn('Try the next URL')
+                logger.debug('Try the next URL')
                 continue
         raise exceptions.HttpException(
             'Unable to {} data from any of the available '
@@ -538,11 +606,11 @@ class StorageInventoryClient(object):
                 duration = time.time() - start
                 logger.debug('{} removed in {} ms'.format(id, duration))
                 return
-            except (exceptions.HttpException, socket.timeout) as e:
+            except exceptions.TransferException as e:
                 # try a different URL
-                logger.info('WARN: Cannot remove data from {}. Exception: {}'.
+                logger.debug('WARN: Cannot remove data from {}. Exception: {}'.
                             format(url, e))
-                logger.warn('Try the next URL')
+                logger.debug('Try the next URL')
                 continue
         raise exceptions.HttpException(
             'Unable to remove data from any of the available URLs')
@@ -595,15 +663,6 @@ class StorageInventoryClient(object):
         return hash_md5.hexdigest()
 
 
-class DownloadError(Exception):
-    """Download error (file corrupted)
-    Attributes:
-        msg
-    """
-    def __init__(self, msg=None):
-        Exception.__init__(self, msg)
-
-
 def cadcput_cli():
     parser = util.get_base_parser(subparsers=False,
                                   version=version.version,
@@ -653,11 +712,8 @@ def cadcput_cli():
         '      cadcput -v -u auser cadc:TEST/ myfile.fits.gz dir1 dir2')
 
     args = parser.parse_args()
-    _set_logging_level(args)
-    subject = net.Subject.from_cmd_line_args(args)
+    client = _create_client(args)
 
-    client = StorageInventoryClient(subject, args.service, host=args.host,
-                                    insecure=args.insecure)
     files = []
     for file in args.src:
         if os.path.isdir(file):
@@ -713,10 +769,7 @@ def cadcget_cli():
         '        cadc:CFHT/700000o[1]\n')
 
     args = parser.parse_args()
-    _set_logging_level(args)
-    subject = net.Subject.from_cmd_line_args(args)
-    client = StorageInventoryClient(subject, args.service, host=args.host,
-                                    insecure=args.insecure)
+    client = _create_client(args)
     logger.info('GET id {} -> {}'.format(
         args.identifier, args.output if args.output else 'stdout'))
     execute_cmd(client.cadcget, {'id': args.identifier, 'dest': args.output})
@@ -740,10 +793,7 @@ def cadcinfo_cli():
         '        cadcinfo gemini:GEMINI/00aug02_002.fits\n')
 
     args = parser.parse_args()
-    _set_logging_level(args)
-    subject = net.Subject.from_cmd_line_args(args)
-    client = StorageInventoryClient(subject, args.service, host=args.host,
-                                    insecure=args.insecure)
+    client = _create_client(args)
     for id in args.identifier:
         logger.info('INFO for id {}'.format(id))
         try:
@@ -781,10 +831,7 @@ def cadcremove_cli():
         '       cadcremove --cert ~/.ssl/cadcproxy.pem cadc:CFHT/700000o.fz\n')
 
     args = parser.parse_args()
-    _set_logging_level(args)
-    subject = net.Subject.from_cmd_line_args(args)
-    client = StorageInventoryClient(subject, args.service, host=args.host,
-                                    insecure=args.insecure)
+    client = _create_client(args)
     for id in args.identifier:
         logger.info('REMOVE id {}'.format(id))
         execute_cmd(client.cadcremove, {'id': id})
@@ -801,33 +848,19 @@ def _set_logging_level(args):
         logging.basicConfig(level=logging.WARN, stream=sys.stdout)
 
 
-def execute_cmd(cmd, cmd_args):
-    def handle_error(msg, exit_after=True):
-        """
-        Prints error message and exit (by default)
-        :param msg: error message to print
-        :param exit_after: True if log error message and exit,
-        False if log error message and return
-        :return:
-        """
+def _create_client(args):
+    # creates a StorageInventory client based on the cmd line args
+    try:
+        _set_logging_level(args)
+        subject = net.Subject.from_cmd_line_args(args)
+        return StorageInventoryClient(subject, args.service, host=args.host,
+                                      insecure=args.insecure)
+    except Exception as ex:
+        handle_error(str(ex))
 
-        print('ERROR: {}'.format(msg))
-        if exit_after:
-            sys.exit(-1)  # TODO use different error codes?
+
+def execute_cmd(cmd, cmd_args):
     try:
         return cmd(**cmd_args)
-    except exceptions.UnauthorizedException:
-        # TODO - magic authentication
-        # if subject.anon:
-        #     handle_error('Operation cannot be performed anonymously. '
-        #                  'Use one of the available methods to authenticate')
-        # else:
-        handle_error('Unexpected authentication problem')
-    except exceptions.NotFoundException as not_found:
-        handle_error('Not found: {}'.format(str(not_found)))
-    except exceptions.ForbiddenException:
-        handle_error('Unauthorized to perform operation')
-    except exceptions.UnexpectedException as e:
-        handle_error('Unexpected server error: {}'.format(str(e)))
     except Exception as e:
-        handle_error(str(e))
+        handle_error(e)

--- a/cadcdata/cadcdata/tests/test_inventory.py
+++ b/cadcdata/cadcdata/tests/test_inventory.py
@@ -503,9 +503,15 @@ def test_cadcinfo_cli(cadcinfo_mock):
     assert expected == stdout_mock.getvalue()
 
 
-@patch('sys.exit', Mock(side_effect=[MyExitError, MyExitError, MyExitError]))
-@patch('cadcdata.StorageInventoryClient.cadcput')
-def test_cadcput_cli(cadcput_mock):
+@patch('sys.exit', Mock(side_effect=[MyExitError, MyExitError, MyExitError, MyExitError, MyExitError]))
+@patch('cadcdata.storageinv._create_client')
+def test_cadcput_cli(putclient_mock):
+    # mock client to escape authentication
+    mock_client = StorageInventoryClient()
+    cadcput_mock = Mock()
+    mock_client.cadcput = cadcput_mock
+    putclient_mock.return_value = mock_client
+
     # create a file structure of files to put
     put_dir = '/tmp/put_dir'
     put_subdir = '{}/somedir'.format(put_dir)
@@ -574,8 +580,13 @@ def test_cadcput_cli(cadcput_mock):
 
 
 @patch('sys.exit', Mock(side_effect=[MyExitError, MyExitError]))
-@patch('cadcdata.StorageInventoryClient.cadcremove')
-def test_cadcremove_cli(cadcremove_mock):
+@patch('cadcdata.storageinv._create_client')
+def test_cadcremove_cli(removeclient_mock):
+    # mock client to escape authentication
+    mock_client = StorageInventoryClient()
+    cadcremove_mock = Mock()
+    mock_client.cadcremove = cadcremove_mock
+    removeclient_mock.return_value = mock_client
     netrc = '/tmp/.cadcput_netrc'
     if not os.path.isfile(netrc):
         open(netrc, 'w').write('')

--- a/cadcdata/cadcdata/tests/test_inventory.py
+++ b/cadcdata/cadcdata/tests/test_inventory.py
@@ -166,7 +166,7 @@ def test_get(trans_mock, basews_mock):
     url_list = ['url1', 'url2']
     trans_mock.return_value.transfer.return_value = list(url_list)  # copy
     get_mock.side_effect = [exceptions.TransferException()] * len(url_list) * \
-                            cadcdata.storageinv.MAX_TRANSIENT_TRIES
+        cadcdata.storageinv.MAX_TRANSIENT_TRIES
     with pytest.raises(exceptions.HttpException):
         client.cadcget('cadc:TEST:bfile.txt', file_name)
     assert get_mock.call_count == \
@@ -239,7 +239,7 @@ def test_get(trans_mock, basews_mock):
     # this is considered a TransferException so the client is going to
     # try MAX_TRANSIENT_TRIES for each url in the list
     get_mock.side_effect = [response] * len(url_list) * \
-                            cadcdata.storageinv.MAX_TRANSIENT_TRIES
+        cadcdata.storageinv.MAX_TRANSIENT_TRIES
     with pytest.raises(exceptions.HttpException):
         client.cadcget('cadc:TEST/afile', dest='/dev/null',
                        process_bytes=concatenate_chunks)
@@ -424,7 +424,7 @@ def test_put(basews_mock):
     url_list = ['url1', 'url2']
     client._get_transfer_urls = Mock(return_value=list(url_list))  # copy list
     put_mock.side_effect = [exceptions.TransferException()] * 2 * \
-                            cadcdata.storageinv.MAX_TRANSIENT_TRIES
+        cadcdata.storageinv.MAX_TRANSIENT_TRIES
     client.cadcinfo = Mock(side_effect=exceptions.NotFoundException())
     with pytest.raises(exceptions.HttpException):
         client.cadcput('cadc:TEST/putfile', file_name,
@@ -612,8 +612,7 @@ def test_cadcinfo_cli(cadcinfo_mock):
     assert expected == stdout_mock.getvalue()
 
 
-@patch('sys.exit', Mock(side_effect=[MyExitError, MyExitError, MyExitError,
-                                     MyExitError, MyExitError, MyExitError]))
+@patch('sys.exit', Mock(side_effect=[MyExitError, MyExitError, MyExitError]))
 @patch('cadcdata.storageinv._create_client')
 def test_cadcput_cli(putclient_mock):
     # mock client to escape authentication

--- a/cadcdata/dev_requirements.txt
+++ b/cadcdata/dev_requirements.txt
@@ -4,5 +4,5 @@ pytest>=4.6
 pytest-cov>=2.5.1
 flake8>=3.4.1
 funcsigs==1.0.2
-mock==2.0.0
-xml-compare==1.0.5
+mock>=2.0.0
+xml-compare>=1.0.5

--- a/cadcdata/pytest.ini
+++ b/cadcdata/pytest.ini
@@ -1,2 +1,2 @@
 [pytest]
-markers = intTest: marks tests as integration test (deselect with '-m "not intTest"')
+markers = intTests: marks tests as integration test (deselect with '-m "not intTests"')

--- a/cadctap/cadctap/tests/__init__.py
+++ b/cadctap/cadctap/tests/__init__.py
@@ -1,0 +1,1 @@
+# This exists solely to make coverage collect usage data

--- a/cadctap/dev_requirements.txt
+++ b/cadctap/dev_requirements.txt
@@ -3,6 +3,6 @@
 pytest>=4.6
 pytest-cov>=2.5.1
 flake8>=3.4.1
-funcsigs==1.0.2
-mock==2.0.0
-xml-compare==1.0.5
+funcsigs>=1.0.2
+mock>=2.0.0
+xml-compare>=1.0.5

--- a/cadctap/tox.ini
+++ b/cadctap/tox.ini
@@ -30,7 +30,6 @@ deps:
     -rdev_requirements.txt
 commands =
     pytest {[package]name} --cov {[package]name} --cov-report xml --cov-config={toxinidir}/setup.cfg
-    coverage xml -o {toxinidir}/coverage.xml
 
 
 [testenv:checkstyle]

--- a/cadcutils/cadcutils/exceptions.py
+++ b/cadcutils/cadcutils/exceptions.py
@@ -180,3 +180,14 @@ class UnexpectedException(HttpException):
     """
     def __init__(self, msg=None, orig_exception=None):
         HttpException.__init__(self, msg, orig_exception)
+
+
+class TransferException(HttpException):
+    """A transfer exception was encountered. Client should either try another
+    mirror URL or re-try this if possible (data is still accessible - not
+    streamed)
+    Attributes:
+        msg
+    """
+    def __init__(self, msg=None, orig_exception=None):
+        HttpException.__init__(self, msg, orig_exception)

--- a/cadcutils/cadcutils/net/auth.py
+++ b/cadcutils/cadcutils/net/auth.py
@@ -336,7 +336,7 @@ def get_cert_main():
         # unauthorized
         sys.stderr.write('FAILED: invalid username/password combination')
     except Exception as ex:
-        sys.stderr.write("FAILED to retrieved {} day certificate\n".format(
+        sys.stderr.write("FAILED to retrieve {} day certificate\n".format(
             args.days_valid))
         sys.stderr.write('{}'.format(html2text.html2text(str(ex))))
         return getattr(ex, 'errno', 1)

--- a/cadcutils/cadcutils/net/auth.py
+++ b/cadcutils/cadcutils/net/auth.py
@@ -84,7 +84,7 @@ import sys
 import html2text
 
 from cadcutils.net import ws
-from cadcutils import util
+from cadcutils import util, exceptions
 
 CRED_RESOURCE_ID = 'ivo://cadc.nrc.ca/cred'
 CRED_PROXY_FEATURE_ID = 'ivo://ivoa.net/std/CDP#proxy-1.0'
@@ -332,14 +332,9 @@ def get_cert_main():
             w.write(cert)
         print('DONE. {} day certificate saved in {}'.format(
             args.days_valid, args.cert_filename))
-    except OSError as ose:
-        sys.stderr.write("FAILED to retrieved {} day certificate\n".format(
-            args.days_valid))
-        if ose.errno != 401:
-            sys.stderr.write(html2text.html2text(str(ose)))
-            return getattr(ose, 'errno', 1)
-        else:
-            sys.stderr.write("Access denied\n")
+    except exceptions.UnauthorizedException:
+        # unauthorized
+        sys.stderr.write('FAILED: invalid username/password combination')
     except Exception as ex:
         sys.stderr.write("FAILED to retrieved {} day certificate\n".format(
             args.days_valid))

--- a/cadcutils/cadcutils/net/tests/__init__.py
+++ b/cadcutils/cadcutils/net/tests/__init__.py
@@ -1,0 +1,1 @@
+# This exists solely to make coverage collect usage data

--- a/cadcutils/cadcutils/net/tests/test_ws.py
+++ b/cadcutils/cadcutils/net/tests/test_ws.py
@@ -392,6 +392,17 @@ class TestRetrySession(unittest.TestCase):
         rs.send(request, timeout=77)
         send_mock.assert_called_with(request, timeout=77)
 
+        # mock delays for timeout
+        send_mock.reset_mock()
+        rs = ws.RetrySession()
+        # connection error that triggers retries
+        te = requests.exceptions.Timeout()
+        response = requests.Response()
+        response.status_code = requests.codes.ok
+        send_mock.side_effect = [te, response]
+        rs.send(request)
+        time_mock.assert_called_with(DEFAULT_RETRY_DELAY)
+
         # mock delays for the 'Connection reset by peer error'
         # one connection error delay = DEFAULT_RETRY_DELAY
         send_mock.reset_mock()

--- a/cadcutils/cadcutils/net/tests/test_ws.py
+++ b/cadcutils/cadcutils/net/tests/test_ws.py
@@ -392,37 +392,51 @@ class TestRetrySession(unittest.TestCase):
         rs.send(request, timeout=77)
         send_mock.assert_called_with(request, timeout=77)
 
-        # mock delays for timeout
+        # mock delays for connect timeout
         send_mock.reset_mock()
         rs = ws.RetrySession()
         # connection error that triggers retries
-        te = requests.exceptions.Timeout()
+        cte = requests.exceptions.ConnectTimeout()
         response = requests.Response()
         response.status_code = requests.codes.ok
-        send_mock.side_effect = [te, response]
+        send_mock.side_effect = [cte, response]
         rs.send(request)
         time_mock.assert_called_with(DEFAULT_RETRY_DELAY)
 
-        # mock delays for the 'Connection reset by peer error'
-        # one connection error delay = DEFAULT_RETRY_DELAY
+        # mock delays for read timeout
         send_mock.reset_mock()
         rs = ws.RetrySession()
         # connection error that triggers retries
-        ce = requests.exceptions.ConnectionError()
-        ce.errno = 104
-        response = requests.Response()
-        response.status_code = requests.codes.ok
-        send_mock.side_effect = [ce, response]
-        rs.send(request)
-        time_mock.assert_called_with(DEFAULT_RETRY_DELAY)
+        rte = requests.exceptions.ReadTimeout()
+        send_mock.side_effect = [rte]
+        with self.assertRaises(exceptions.TransferException):
+            rs.send(request)
+
+        # mock Connection errors
+        send_mock.reset_mock()
+        rs = ws.RetrySession()
+        # connection error that triggers retries
+        ce = requests.exceptions.ConnectionError('Some error')
+        send_mock.side_effect = [ce]
+        with self.assertRaises(exceptions.HttpException):
+            rs.send(request)
+
+        # mock reset by peer error
+        # mock Connection errors
+        send_mock.reset_mock()
+        rs = ws.RetrySession()
+        # connection error that triggers retries
+        ce = requests.exceptions.ConnectionError('Connection reset by peer')
+        send_mock.side_effect = [ce]
+        with self.assertRaises(exceptions.TransferException):
+            rs.send(request)
 
         # two connection error delay = DEFAULT_RETRY_DELAY
         send_mock.reset_mock()
         time_mock.reset_mock()
         rs = ws.RetrySession()
         # connection error that triggers retries
-        ce = requests.exceptions.ConnectionError()
-        ce.errno = 104
+        ce = requests.exceptions.ConnectTimeout()
         response = requests.Response()
         response.status_code = requests.codes.ok
         send_mock.side_effect = [ce, ce, response]  # two connection errors
@@ -436,8 +450,7 @@ class TestRetrySession(unittest.TestCase):
         time_mock.reset_mock()
         rs = ws.RetrySession(start_delay=MAX_RETRY_DELAY / 2 + 1)
         # connection error that triggers retries
-        ce = requests.exceptions.ConnectionError()
-        ce.errno = 104
+        ce = requests.exceptions.ConnectTimeout()
         response = requests.Response()
         response.status_code = requests.codes.ok
         send_mock.side_effect = [ce, ce, response]  # two connection errors
@@ -450,8 +463,7 @@ class TestRetrySession(unittest.TestCase):
         time_mock.reset_mock()
         rs = ws.RetrySession(start_delay=MAX_RETRY_DELAY / 2 + 1)
         # connection error that triggers retries
-        ce = requests.exceptions.ConnectionError()
-        ce.errno = 104
+        ce = requests.exceptions.ConnectTimeout()
         # make sure the mock returns more errors than the maximum number
         # of retries allowed
         http_errors = []
@@ -460,17 +472,6 @@ class TestRetrySession(unittest.TestCase):
             http_errors.append(ce)
             i += 1
         send_mock.side_effect = http_errors
-        with self.assertRaises(exceptions.HttpException):
-            rs.send(request)
-
-        # return the connection error other than 104 - connection reset by peer
-        send_mock.reset_mock()
-        time_mock.reset_mock()
-        rs = ws.RetrySession(start_delay=MAX_RETRY_DELAY / 2 + 1)
-        # connection error that triggers retries
-        ce = requests.exceptions.ConnectionError()
-        ce.errno = 105
-        send_mock.side_effect = ce
         with self.assertRaises(exceptions.HttpException):
             rs.send(request)
 

--- a/cadcutils/cadcutils/net/ws.py
+++ b/cadcutils/cadcutils/net/ws.py
@@ -488,6 +488,9 @@ class RetrySession(Session):
                                                               **kwargs)
                     self.check_status(response)
                     return response
+                except requests.exceptions.Timeout as te:
+                    # retry on timeouts
+                    self.logger.debug(te)
                 except requests.HTTPError as e:
                     if e.response.status_code not in self.retry_errors:
                         raise exceptions.HttpException(e)
@@ -518,7 +521,7 @@ class RetrySession(Session):
                     if ce.errno != 104:
                         # Only continue trying on a reset by peer error.
                         raise exceptions.HttpException(orig_exception=ce)
-                self.logger.warning(
+                self.logger.debug(
                     "Resending request in {}s ...".format(current_delay))
                 time.sleep(current_delay)
                 num_retries += 1

--- a/cadcutils/cadcutils/util/tests/test_config.py
+++ b/cadcutils/cadcutils/util/tests/test_config.py
@@ -3,7 +3,7 @@ import os
 import tempfile
 import shutil
 import uuid
-import unittest2 as unittest
+import unittest
 from cadcutils.util import config
 
 _ROOT = os.path.abspath(os.path.dirname(__file__))

--- a/cadcutils/dev_requirements.txt
+++ b/cadcutils/dev_requirements.txt
@@ -1,9 +1,8 @@
--e . 
+-e ../cadcutils
+-e ../cadcdata
 pytest
-tox
 pytest-cov>=2.5.1
 flake8>=3.4.1
 funcsigs==1.0.2
 mock>=2.0.0
 xml-compare>=1.0.5
-unittest2>=1.1.0

--- a/cadcutils/setup.cfg
+++ b/cadcutils/setup.cfg
@@ -41,7 +41,7 @@ install_requires =
     lxml>=3.7.0;python_version>="3.5"
     lxml;python_version=="2.7"
     six html2text distro pyopenssl
-version = 1.2.1
+version = 1.2.2
 
 [entry_points]
 cadc-get-cert = cadcutils.net.auth:get_cert_main

--- a/cadcutils/setup.cfg
+++ b/cadcutils/setup.cfg
@@ -41,7 +41,7 @@ install_requires =
     lxml>=3.7.0;python_version>="3.5"
     lxml;python_version=="2.7"
     six html2text distro pyopenssl
-version = 1.2.0
+version = 1.2.1
 
 [entry_points]
 cadc-get-cert = cadcutils.net.auth:get_cert_main

--- a/cadcutils/tox.ini
+++ b/cadcutils/tox.ini
@@ -31,7 +31,6 @@ deps:
 commands =
     pytest {[package]name} --cov {[package]name} --cov-report xml --cov-config={toxinidir}/setup.cfg
 
-
 [testenv:checkstyle]
 description = check code style, e.g. with flake8
 # We list the warnings/errors to check for here rather than in setup.cfg because


### PR DESCRIPTION
This is a fix to make CADC Python clients more robust to network timeout and connection errors.

There are 2 types of HTTP errors:

1. errors that occur prior to the request being processed by the server: Connection Timeout, various HTTP 500 & 400 errors etc.
2. errors the occur after connection during the transfer of the bytes: Read Timeout, Connection reset by peer, Corrupted files etc.

The first category of errors can be further classified in intermittent and permanent errors. The `cadcutils.net.RetrySession` automatically re-tries the request on intermittent errors but throws the other exceptions to the caller as they are probably mistakes or bugs (incorrect URL, etc). The class also tries to identify the errors that occur during `PUT` bytes transfer and throw a `TransferException`. Caller might be able to restart the request if the data stream is still available (was not streamed). The receiving of streamed data from `GET` is in the caller loop and the caller (`cadcdata` application for ex).


